### PR TITLE
Remove PrebuiltExchange3Google

### DIFF
--- a/modules/PrebuiltExchange3Google/Android.mk
+++ b/modules/PrebuiltExchange3Google/Android.mk
@@ -1,9 +1,0 @@
-LOCAL_PATH := .
-include $(CLEAR_VARS)
-include $(GAPPS_CLEAR_VARS)
-LOCAL_MODULE := PrebuiltExchange3Google
-LOCAL_PACKAGE_NAME := com.google.android.gm.exchange
-
-LOCAL_OVERRIDES_PACKAGES := Exchange2
-
-include $(BUILD_GAPPS_PREBUILT_APK)

--- a/opengapps-packages.mk
+++ b/opengapps-packages.mk
@@ -26,7 +26,6 @@ PRODUCT_PACKAGES += FaceLock \
 
 ifneq ($(filter $(TARGET_GAPPS_VARIANT),micro),) # require at least micro
 PRODUCT_PACKAGES += CalendarGooglePrebuilt \
-                    PrebuiltExchange3Google \
                     PrebuiltGmail \
                     GoogleHome
                     


### PR DESCRIPTION
@mfonville :
I did remove this package yesterday, because the functionality is now integrated
in the GMail app and the google exchange service has been removed from the
latest Nexus image.

(so PrebuiltExchange3Google should be removed from the buildlist)